### PR TITLE
fix: set user when running container to avoid error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,16 +4,16 @@ A docker image for `git-fame`.
 ## Usage
 Run by going to the root of the git repo you want to analyse and run:
 ```bash
-docker run --rm -v "${PWD}":/src joshkeegan/git-fame
+docker run --rm -v "${PWD}":/src --user "$(id -u):$(id -g)" joshkeegan/git-fame
 ```
 
 If you want to use arguments, simply supply them at the end of the command, e.g.
 ```bash
-docker run --rm -v "${PWD}":/src joshkeegan/git-fame --by-type
+docker run --rm -v "${PWD}":/src --user "$(id -u):$(id -g)" joshkeegan/git-fame --by-type
 ```
 
 If running on windows via mingw, disable path conversions for the volume mount to work:
 ```bash
-export MSYS_NO_PATHCONV=1 && docker run --rm -v "${PWD}":/src joshkeegan/git-fame
+export MSYS_NO_PATHCONV=1 && docker run --rm -v "${PWD}":/src --user "$(id -u):$(id -g)" joshkeegan/git-fame
 ```
 ...and make sure the docker VM has access to the drive you're volume mounting.


### PR DESCRIPTION
If not set, got the error "repository path '/src/' is not owned by current user"